### PR TITLE
fix: packaging hygiene — react peers, types/exports map, files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-duo-toggle-switch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fully customizable animated duo toggle switch for React Native",
   "keywords": [
     "FreakyCoder",
@@ -46,5 +46,21 @@
     "husky:setup": "npx husky-init && npm run husky:commitlint && npm run husky:prettier",
     "husky:commitlint": "npx husky add .husky/commit-msg 'npx --no-install commitlint --edit'",
     "husky:prettier": "npx husky add .husky/pre-commit 'npm run prettier'"
-  }
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0",
+    "react-native": ">=0.64.0"
+  },
+  "types": "./build/dist/DuoToggleSwitch.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/dist/DuoToggleSwitch.d.ts",
+      "default": "./build/dist/DuoToggleSwitch.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "build/dist",
+    "!build/dist/tsconfig.tsbuildinfo"
+  ]
 }


### PR DESCRIPTION
Packaging-hygiene pass mirroring react-native-bouncy-checkbox #822. package.json only, no source changes.

- **peerDependencies**: none were declared — added `react >=17.0.0`, `react-native >=0.64.0`.
- **types + exports map**: added, pointing at the published `build/dist` output (`DuoToggleSwitch.js` / `.d.ts`), types condition first, `./package.json` export included.
- **files whitelist**: the published 1.1.0 tarball ships `.expo/` settings, TypeScript sources (`lib/`), `tsconfig.json`, `tsconfig.tsbuildinfo`, `.eslintrc.js`, `.prettierrc`, `.commitlintrc.json` — now trimmed to `build/dist`.
- **Version**: 1.1.0 → 1.1.1.

LICENSE file present ✓

Publish as 1.1.1 after the npm account migration.